### PR TITLE
Update Minimum Supported Version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginSinceBuild = 203.5981.141
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.3, 2020.3.2, 2021.1
+pluginVerifierIdeVersions = 2020.3.2, 2021.1
 
 platformType = RD
 platformVersion = 2020.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes - Rider Extension
 pluginVersion = 0.2.1
-pluginSinceBuild = 202.6397.94
+pluginSinceBuild = 203.5981.141
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.2, 2020.2.3, 2020.3.2
+pluginVerifierIdeVersions = 2020.3, 2020.3.2, 2021.1
 
 platformType = RD
 platformVersion = 2020.3.3

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,8 @@
   <name>Anime Memes - Rider Extension</name>
   <vendor>Unthrottled</vendor>
 
+  <idea-version since-build="203.5981.141"/>
+
   <!-- Product and plugin compatibility requirements -->
   <!-- https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
   <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
# Changes

- Bumped minimum supported IDE version to 2020.3

# Motivation

- The unit test functionality is not available until 2020.3

