### PR TITLE
Able to react to first test events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # AMII Rider Extensions Changelog
 
+## [0.2.2]
+
+## Fixed
+
+- MIKU not reacting to test the first time you ever run them.
+
 ## [0.2.1]
 
 ## Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.changelog.closure
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -127,6 +128,7 @@ tasks {
   }
 
   runPluginVerifier {
+    setFailureLevel(FailureLevel.COMPATIBILITY_PROBLEMS)
     ideVersions(pluginVerifierIdeVersions)
   }
 

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-### Fixed
-- Unit-Test reactions not showing up in Rider.
-- Build Task reactions not showing up in Rider.
+## Fixed
+
+- MIKU not reacting to test the first time you ever run them.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes - Rider Extension
-pluginVersion = 0.2.1
+pluginVersion = 0.2.2
 pluginSinceBuild = 203.5981.141
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
@@ -11,7 +11,7 @@ pluginUntilBuild = 211.*
 pluginVerifierIdeVersions = 2020.3.2, 2021.1
 
 platformType = RD
-platformVersion = 2020.3.3
+platformVersion = 2021.1.2
 platformDownloadSources = true
 
 idePath=

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginSinceBuild = 203.5981.141
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.3.2, 2021.1
+pluginVerifierIdeVersions = RD-2020.3.2, RD-2021.1
 
 platformType = RD
 platformVersion = 2021.1.2

--- a/src/main/kotlin/io/unthrottled/amii/rider/listeners/RiderTestListener.kt
+++ b/src/main/kotlin/io/unthrottled/amii/rider/listeners/RiderTestListener.kt
@@ -27,7 +27,14 @@ class RiderTestListener(
       runningTests[sessionKey] = false
       val state = it.newValueOpt?.state
       state?.advise(projectComponentLifetime) { sessionState ->
-        if (sessionState.message == "Running" && runningTests[sessionKey] != true) {
+        val sessionStateMessage = sessionState.message
+        if ((
+          "Running".equals(sessionStateMessage, ignoreCase = true) ||
+            // when the test UI window is first open
+            // running is not seen, but finishing is.
+            "Finishing".equals(sessionStateMessage, ignoreCase = true)
+          ) && runningTests[sessionKey] != true
+        ) {
           runningTests[sessionKey] = true
         } else if (runningTests[sessionKey] == true) {
           if (sessionState.completedCount == sessionState.totalCount) {


### PR DESCRIPTION
## Changes

- Listening to the first test run events, so that way users get a reaction when their first test completes.

## Motivation

Closes #10

## Notes 

Bug was reproducible and verified fixed in this environment

```
JetBrains Rider 2021.1.2
Build #RD-211.7142.19, built on April 22, 2021
Licensed to Alex Simons
Subscription is active until February 20, 2022.
Runtime version: 11.0.10+9-b1341.41 amd64
VM: Dynamic Code Evolution 64-Bit Server VM by JetBrains s.r.o.
Linux 5.4.0-72-generic
.NET Core 5.0.5
GC: G1 Young Generation, G1 Old Generation
Memory: 1500M
Cores: 12
Registry: debugger.new.debug.tool.window.view=true, ide.tree.horizontal.default.autoscrolling=false, performance.watcher.sampling.interval.ms=200, ide.borderless.tab.caption.in.title=false, ide.tooltip.showAllSeverities=true, show.diff.preview.as.editor.tab=true, light.edit.file.open.enabled=false, performance.watcher.unresponsive.interval.ms=1000, search.everywhere.settings=true, show.diff.preview.as.editor.tab.with.single.click=true, ea.enable.developers.list=false, parameter.info.max.visible.rows=10, ide.win.file.chooser.native=true, vcs.log.show.diff.preview.as.editor.tab=true, actionSystem.fix.alt.gr=false, search.everywhere.pattern.checking=false, ide.tooltip.initialDelay=0, ide.mac.bigsur.window.with.tabs.enabled=false, ide.require.transaction.for.model.changes=false, ide.debug.in.title=true, rdclient.asyncActions=false, rider.enable.designer.winForms=false
Non-Bundled Plugins: IdeaVIM (0.66), io.acari.DDLCTheme (15.0.0), io.unthrottled.amii (0.9.2), io.unthrottled.amii.rider (0.2.2), com.microsoft.vso.idea (1.161.1)
Current Desktop: ubuntu:GNOME
```
